### PR TITLE
Comparator operands the wrong way around

### DIFF
--- a/src/Comparator.cpp
+++ b/src/Comparator.cpp
@@ -13,9 +13,9 @@ struct Comparator : Module {
     INPUTS_LEN
   };
   enum OutputId {
-    LESS_OUTPUT,
-    EQUAL_OUTPUT,
     GREATER_OUTPUT,
+    EQUAL_OUTPUT,
+    LESS_OUTPUT,
     OUTPUTS_LEN
   };
   enum LightId {

--- a/src/Comparator.cpp
+++ b/src/Comparator.cpp
@@ -74,9 +74,9 @@ struct Comparator : Module {
 
       float b = inputs[B_INPUT].getVoltage(bMono ? 0 : c);
 
-      if (b < a - tolerance) {
+      if (a < b - tolerance) {
         outputs[LESS_OUTPUT].setVoltage(10.0f, c);
-      } else if (b > a + tolerance) {
+      } else if (a > b + tolerance) {
         outputs[GREATER_OUTPUT].setVoltage(10.0f, c);
       } else {
         outputs[EQUAL_OUTPUT].setVoltage(10.0f, c);


### PR DESCRIPTION
Hiya, I noticed the label (and naming in the code) for your Comparator claims "A < B", but the output behaves as "A > B", as you can see in my screenshot here.
![image](https://user-images.githubusercontent.com/1371085/173757547-6f12b90b-a30a-416f-ad2e-9b85b14c1579.png)

I think the naming for everything in the code makes sense; I tried to address this by swapping the operands, rather than the operator. This way `a < b` matches the labelling.

Thanks!